### PR TITLE
Bump to ffmpeg 4.2.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,8 +171,8 @@ EXTERNALPROJECT_ADD(
 EXTERNALPROJECT_ADD(
   ffmpeg
   DEPENDS yasm opencore-amr lame libogg speex libvorbis libtheora opus x264 x265 libvpx freetype libass aom mbedtls
-  # URL https://ffmpeg.org/releases/ffmpeg-4.2.1.tar.bz2
-  URL ${CMAKE_SOURCE_DIR}/vendor/ffmpeg-4.2.1.tar.bz2
+  # URL https://ffmpeg.org/releases/ffmpeg-4.2.3.tar.bz2
+  URL ${CMAKE_SOURCE_DIR}/vendor/ffmpeg-4.2.3.tar.bz2
   CONFIGURE_COMMAND PATH=$ENV{PATH} PKG_CONFIG_PATH=$ENV{PKG_CONFIG_PATH} ./configure --prefix=${CMAKE_BINARY_DIR} --datadir=${CMAKE_BINARY_DIR}/etc --disable-shared --enable-static --enable-pic --pkg-config-flags=--static --enable-gpl --enable-version3 --disable-doc --disable-debug --disable-ffplay --disable-outdevs --enable-runtime-cpudetect --extra-cflags=-I${CMAKE_BINARY_DIR}/include\ -static --extra-ldflags=-L${CMAKE_BINARY_DIR}/lib --extra-ldexeflags=-static --extra-libs=-lstdc++\ -lexpat\ -ldl\ -lm\ -lpthread --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libaom --enable-libmp3lame --enable-libspeex --enable-libtheora --enable-libvorbis --enable-libx264 --enable-libx265 --enable-libvpx --enable-libopus --enable-libfreetype --enable-libass --enable-mbedtls
   BUILD_COMMAND PATH=$ENV{PATH} make
   BUILD_IN_SOURCE 1

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+sffmpeg (4.2.3) stable; urgency=medium
+
+  * upgrade to FFmpeg 4.2.3
+
+ -- Craig Ingram <cingram@heroku.com>  Thu, 12 Jun 2020 12:00:00 +0200
+
 sffmpeg (4.2.1-2) stable; urgency=medium
 
   * fix non-static dependencies


### PR DESCRIPTION
> Fixes following vulnerabilities:
> 
> CVE-2019-13312, eae4b6142223d6f214b97c00bc498884f3b98065 / def04022f4a7058f99e669bfd978d431d79aec18
> CVE-2020-12284, 838105153a579ff0cea0794afc0275c19c51d3a7 / 1812352d767ccf5431aa440123e2e260a4db2726

https://ffmpeg.org/security.html